### PR TITLE
Prevent comment to be upvoted/downvoted more than once by same visitor

### DIFF
--- a/inc/class-comment-popularity.php
+++ b/inc/class-comment-popularity.php
@@ -186,6 +186,7 @@ class HMN_Comment_Popularity {
 		$comment_weight = $this->get_comment_weight( $comment_id );
 
 		$container_classes = array( 'comment-weight-container' );
+
 		if ( ! $this->user_can_vote( get_current_user_id(), $comment_id ) ) {
 			$container_classes[] = 'voting-disabled';
 		}
@@ -501,7 +502,7 @@ class HMN_Comment_Popularity {
 	 *
 	 * @return bool
 	 */
-	public function user_can_vote( $user_id, $comment_id, $action ) {
+	public function user_can_vote( $user_id, $comment_id, $action = '' ) {
 
 		if ( ! current_user_can( 'vote_on_comments' ) ) {
 			return new WP_Error( 'insufficient_permissions', __( 'You lack sufficient permissions to vote on comments', 'comment-popularity' ) );


### PR DESCRIPTION
See: https://github.com/humanmade/comment-popularity/pull/31#discussion_r15438129

Once a visitor has upvoted or downvoted, his next action can only be the opposite. In order to prevent multiple upvotes of same comment by visitor.
- Track last action, and save to voting history user meta.
- On new vote, check if action is allowed ( if action is same as saved previous action, disallow vote )
