### PR TITLE
Added $comment_popularity as global variable

### DIFF
--- a/comment-popularity.php
+++ b/comment-popularity.php
@@ -26,6 +26,7 @@ require_once plugin_dir_path( __FILE__ ) . 'inc/class-comment-popularity.php';
 register_activation_hook( __FILE__, array( 'CommentPopularity\HMN_Comment_Popularity', 'activate' ) );
 
 function hmn_cp_init() {
+	global $comment_popularity;
 
 	$comment_popularity = CommentPopularity\HMN_Comment_Popularity::get_instance();
 


### PR DESCRIPTION
In order to remove filter from 'comments_template', from functions.php is necessary to access $comment_popularity.