### PR TITLE
Widgets are not loading

### DIFF
--- a/comment-popularity.php
+++ b/comment-popularity.php
@@ -42,7 +42,7 @@ function hmn_cp_init() {
 	}
 
 }
-add_action( 'init', 'hmn_cp_init' ); // BuddyPress complains if set earlier
+add_action( 'plugins_loaded', 'hmn_cp_init' );
 
 // Admin class
 if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {


### PR DESCRIPTION
This is caused by initializing the plugin on the `init` hook instead of `plugins_loaded`
